### PR TITLE
fix: move log to debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial project forked from Tuweni [dns discovery](https://github.com/tmio/tuweni/tree/main/dns-discovery)
-- Move DNS error log to debug level as it is spammy[#2]https://github.com/Consensys/besu-dns-discovery/pull/2()
+- Move DNS error log to debug level as it is spammy[#2](https://github.com/Consensys/besu-dns-discovery/pull/2)
 - Catch all exceptions to avoid any uncaught exceptions [#3](https://github.com/Consensys/besu-dns-discovery/pull/3)
 
 ## [0.0.1] - 2024-05-21

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial project forked from Tuweni [dns discovery](https://github.com/tmio/tuweni/tree/main/dns-discovery)
+- Move DNS error log to debug level as it is spammy[#2]https://github.com/Consensys/besu-dns-discovery/pull/2()
 
 ## [0.0.1] - 2024-05-21
 

--- a/src/main/kotlin/io/consensys/protocols/util/discovery/DNSResolver.kt
+++ b/src/main/kotlin/io/consensys/protocols/util/discovery/DNSResolver.kt
@@ -153,7 +153,7 @@ class DNSResolver @JvmOverloads constructor(
         return null
       }
     } catch (e: DnsException) {
-      logger.warn("DNS query error with $domainName", e)
+      logger.debug("DNS query error with $domainName", e)
       return null
     } catch (e: IOException) {
       logger.warn("I/O exception contacting remote DNS server when resolving $domainName", e)


### PR DESCRIPTION
I suggest changing the DNS error log level to debug as this log is causing a lot of spam and alarming many users who think it's a serious error when it's not that severe. I believe it would be preferable to set it to debug so we are not spammed with this log at the info level.

this is a recreation of https://github.com/tmio/tuweni/pull/50

## Changelog

- [x] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [ ] I thought about testing these changes in a realistic/non-local environment.
