### PR TITLE
fix: DNS Resolver - catch for all exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial project forked from Tuweni [dns discovery](https://github.com/tmio/tuweni/tree/main/dns-discovery)
+- Catch all exceptions to avoid any uncaught exceptions [#3](https://github.com/Consensys/besu-dns-discovery/pull/3)
 
 ## [0.0.1] - 2024-05-21
 

--- a/src/main/kotlin/io/consensys/protocols/util/discovery/DNSResolver.kt
+++ b/src/main/kotlin/io/consensys/protocols/util/discovery/DNSResolver.kt
@@ -19,6 +19,7 @@ package io.consensys.protocols.util.discovery
  */
 
 import io.vertx.core.Vertx
+import io.vertx.core.VertxException
 import io.vertx.core.dns.DnsClient
 import io.vertx.core.dns.DnsClientOptions
 import io.vertx.core.dns.DnsException
@@ -31,6 +32,7 @@ import org.apache.tuweni.crypto.SECP256K1
 import org.apache.tuweni.devp2p.EthereumNodeRecord
 import org.slf4j.LoggerFactory
 import java.io.IOException
+import java.lang.Exception
 
 /**
  * Resolves a set of ENR nodes from a host name.
@@ -157,6 +159,13 @@ class DNSResolver @JvmOverloads constructor(
       return null
     } catch (e: IOException) {
       logger.warn("I/O exception contacting remote DNS server when resolving $domainName", e)
+      return null
+    } catch (e: VertxException) {
+      // timeouts are common
+      logger.warn("Vertx exception contacting remote DNS server when resolving $domainName", e)
+      return null
+    } catch (e: Exception) {
+      logger.warn("Exception contacting remote DNS server when resolving $domainName", e)
       return null
     }
   }


### PR DESCRIPTION
Broaden exception handling to catch any exception - current impl is resulting in this uncaught exception (in besu) and DNS processing halts altogether. Catching this will enable DNS search to continue.

`Uncaught exception in thread “vert.x-eventloop-thread-3”“,”throwable”:” io.vertx.core.VertxException: DNS query timeout for xxx.ethdisco.net ...`



## PR description

## Fixed Issue(s)
Related to this -
https://github.com/hyperledger/besu/issues/1707

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [ ] I thought about testing these changes in a realistic/non-local environment.
