### PR TITLE
feat: start discovery immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial project forked from Tuweni [dns discovery](https://github.com/tmio/tuweni/tree/main/dns-discovery)
+- Don't wait 10 minutes (initial delay) but start DNS discovery immediately
 
 ## [0.0.1] - 2024-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial project forked from Tuweni [dns discovery](https://github.com/tmio/tuweni/tree/main/dns-discovery)
-- Don't wait 10 minutes (initial delay) but start DNS discovery immediately
+- Don't wait 10 minutes (initial delay) but start DNS discovery immediately [#4](https://github.com/Consensys/besu-dns-discovery/pull/4)
 
 ## [0.0.1] - 2024-05-21
 


### PR DESCRIPTION
don't wait 10 minutes (initial delay) but start DNS discovery immediately

## PR Description

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->

## Changelog

- [ ] I thought about adding a changelog entry, and added one if I deemed necessary.

## Testing

- [ ] I thought about testing these changes in a realistic/non-local environment.
